### PR TITLE
fix: license field in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "@dfinity/eslint-config-oisy-wallet",
       "version": "0.0.1",
-      "license": "MIT",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "@typescript-eslint/eslint-plugin": "^6.20.0",
         "eslint": "^8.57.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "best-practices"
   ],
   "author": "",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.20.0",
     "eslint": "^8.57.0",


### PR DESCRIPTION
# Motivation

The lib is licensed under Apache-2.0 but, the package.json contained a field MIT. This resolve this issue by setting Apache-2.0.