### PR TITLE
build: missing repo fields for publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/dfinity/eslint-config-oisy-wallet.git"
   },
   "bugs": {
-    "url": "https://github.com/dfinity/eslint-config-oisy-wallet"
+    "url": "https://github.com/dfinity/eslint-config-oisy-wallet/issues"
   },
   "main": "index.cjs",
   "files": [

--- a/package.json
+++ b/package.json
@@ -3,6 +3,13 @@
   "version": "0.0.1",
   "license": "Apache-2.0",
   "description": "Shared ESLint configurations from the Oisy Wallet team",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dfinity/eslint-config-oisy-wallet.git"
+  },
+  "bugs": {
+    "url": "https://github.com/dfinity/eslint-config-oisy-wallet"
+  },
   "main": "index.cjs",
   "files": [
     "LICENSE",


### PR DESCRIPTION
# Motivation

Repo fields are missing in `package.json` and therefore we cannot publish to npm.

See https://github.com/dfinity/eslint-config-oisy-wallet/actions/runs/11053281386/job/30707280793