### PR TITLE
fix: eslint-local-rules usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ module.exports = require("@dfinity/eslint-config-oisy-wallet/eslint-local-rules"
 ```
 
 > [!NOTE]
-> This is necessary because the `eslint-local-rules` plugin we use for custom rules requires a file located at the root and does not offer any customizable location option.
+> This is necessary because the `eslint-plugin-local-rules` plugin we use for custom rules requires a file located at the root and does not offer any customizable location option.
 
 ## 🛠️ TypeScript Support
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ module.exports = {
 };
 ```
 
+Finally, create an `eslint-local-rules.cjs` file at the root of your project containing the following:
+
+```javascript
+module.exports = require("@dfinity/eslint-config-oisy-wallet/eslint-local-rules");
+```
+
+> [!NOTE]
+> This is necessary because the `eslint-local-rules` plugin we use for custom rules requires a file located at the root and does not offer any customizable location option.
+
 ## 🛠️ TypeScript Support
 
 If your project uses TypeScript, make sure you have a `tsconfig.json` file in your project root.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/eslint-config-oisy-wallet",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/eslint-config-oisy-wallet",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@typescript-eslint/eslint-plugin": "^6.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/eslint-config-oisy-wallet",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "license": "Apache-2.0",
   "description": "Shared ESLint configurations from the Oisy Wallet team",
   "repository": {
@@ -26,6 +26,10 @@
     "./svelte": {
       "import": "./svelte.cjs",
       "require": "./svelte.cjs"
+    },
+    "./eslint-local-rules": {
+      "import": "./eslint-local-rules.cjs",
+      "require": "./eslint-local-rules.cjs"
     }
   },
   "scripts": {


### PR DESCRIPTION
# Motivation

Using this library currently does not work. The root cause is the usage of the `eslint-plugin-local-rules` plugin which require a configuration file at the root of the project where the plugin is used. Not much we can do. Therefore, I tweaked this library to expose the rules we have developed and added an explanation in the README.

I also bumped the lib version as I'll release a new version afterwards.