### PR TITLE
feat: include rule to enforce usage of const

### DIFF
--- a/index.cjs
+++ b/index.cjs
@@ -32,6 +32,14 @@ module.exports = {
     es2017: true,
     node: true,
   },
+  overrides: [
+    {
+      files: ['*.ts'],
+      rules: {
+        'prefer-const': 'error'
+      }
+    }
+  ],
   rules: {
     "@typescript-eslint/consistent-type-definitions": "error",
     "@typescript-eslint/no-inferrable-types": "error",


### PR DESCRIPTION
With the aim of helping us making everything more function, we add rule [prefer-const](https://eslint.org/docs/latest/rules/prefer-const).

The rule prevents unnecessary mutable variable when the variable is not reassigned. Note that we use it only in Typescript files because the `svelte` files require prop and variable declarations to be mutable.