### PR TITLE
feat: more array functions exceptions for prefer-object-params

### DIFF
--- a/eslint-local-rules.cjs
+++ b/eslint-local-rules.cjs
@@ -115,9 +115,35 @@ module.exports = {
           nonNullish(parent) &&
           parent.type === "CallExpression" &&
           parent.callee.type === "MemberExpression" &&
-          ["map", "reduce", "forEach", "filter", "sort", "replace"].includes(
-            parent.callee.property.name,
-          )
+          [
+            "map",
+            "reduce",
+            "forEach",
+            "filter",
+            "sort",
+            "replace",
+            "concat",
+            "copyWithin",
+            "every",
+            "fill",
+            "find",
+            "findIndex",
+            "findLast",
+            "findLastIndex",
+            "flatMap",
+            "includes",
+            "indexOf",
+            "lastIndexOf",
+            "push",
+            "reduce",
+            "reduceRight",
+            "slice",
+            "splice",
+            "toLocaleString",
+            "toSpliced",
+            "unshift",
+            "with",
+          ].includes(parent.callee.property.name)
         ) {
           return;
         }


### PR DESCRIPTION
In the signer standards lib I got following warning:

> /Users/daviddalbusco/projects/dfinity/oisy-wallet-signer/src/icp-wallet.ts
>  104:53  warning  Functions with more than one parameter should accept an object and use destructuring  local-rules/prefer-object-params

I think it's because I use `every` which is not yet whitelisted

```
const uint8ArrayEqual = ({first, second}: {first: Uint8Array; second: Uint8Array}): boolean =>
      first.length === second.length && first.every((value, index) => value === second[index]);
```

Therefore I thought about adding more functions to the list of exception of `prefer-object-params`.