### PR TITLE
feat: avoid relative imports

### DIFF
--- a/eslint-local-rules.cjs
+++ b/eslint-local-rules.cjs
@@ -193,20 +193,17 @@ module.exports = {
   },
   "no-relative-imports": {
     meta: {
-      type: "layout",
-      schema: {
-        type: "problem",
-        docs: {
-          description: "Disallow all relative imports",
-          category: "Best Practices",
-          recommended: false,
-        },
-        messages: {
-          noRelativeImports:
-            "Relative imports are not allowed. Use an alias or absolute imports.",
-        },
-        schema: [],
+      type: "suggestion",
+      docs: {
+        description: "Disallow all relative imports",
+        category: "Best Practices",
+        recommended: false,
       },
+      messages: {
+        noRelativeImports:
+          "Relative imports are not allowed. Use an alias or absolute imports.",
+      },
+      schema: [],
     },
     create(context) {
       return {

--- a/eslint-local-rules.cjs
+++ b/eslint-local-rules.cjs
@@ -1,5 +1,3 @@
-import { join, dirname, relative, sep } from "node:path";
-
 module.exports = {
   "no-svelte-store-in-api": {
     meta: {

--- a/eslint-local-rules.cjs
+++ b/eslint-local-rules.cjs
@@ -1,3 +1,5 @@
+import { join, dirname, relative, sep } from "node:path";
+
 module.exports = {
   "no-svelte-store-in-api": {
     meta: {
@@ -187,6 +189,38 @@ module.exports = {
         },
         ArrowFunctionExpression(node) {
           checkForMoreThanOneParameter(node);
+        },
+      };
+    },
+  },
+  "no-relative-imports": {
+    meta: {
+      type: "layout",
+      schema: {
+        type: "problem",
+        docs: {
+          description: "Disallow all relative imports",
+          category: "Best Practices",
+          recommended: false,
+        },
+        messages: {
+          noRelativeImports:
+            "Relative imports are not allowed. Use an alias or absolute imports.",
+        },
+        schema: [],
+      },
+    },
+    create(context) {
+      return {
+        ImportDeclaration(node) {
+          const path = node.source.value;
+
+          if (path.startsWith("./")) {
+            context.report({
+              node,
+              messageId: "noRelativeImports",
+            });
+          }
         },
       };
     },

--- a/index.cjs
+++ b/index.cjs
@@ -59,6 +59,7 @@ module.exports = {
     "local-rules/prefer-object-params": "warn",
     "local-rules/use-option-type-wrapper": "warn",
     "import/no-duplicates": ["error", { "prefer-inline": true }],
+    "import/no-relative-parent-imports": "error",
     "no-console": ["error", { allow: ["error", "warn"] }],
     "no-continue": "warn",
     "no-delete-var": "error",

--- a/tests/no-relative-imports.spec.ts
+++ b/tests/no-relative-imports.spec.ts
@@ -1,0 +1,27 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+
+const rule = require("../eslint-local-rules.cjs")["no-relative-imports"];
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-relative-imports", rule, {
+    valid: [
+        {
+            code: 'import moduleA from "moduleA";',
+        },
+        {
+            code: 'import { something } from "@alias/something";',
+        },
+    ],
+
+    invalid: [
+        {
+            code: 'import moduleB from "./moduleB";',
+            errors: [{ messageId: "noRelativeImports" }],
+        },
+        {
+            code: 'import moduleC from "./path/moduleC";',
+            errors: [{ messageId: "noRelativeImports" }],
+        },
+    ],
+});

--- a/tests/no-relative-imports.spec.ts
+++ b/tests/no-relative-imports.spec.ts
@@ -5,23 +5,23 @@ const rule = require("../eslint-local-rules.cjs")["no-relative-imports"];
 const ruleTester = new RuleTester();
 
 ruleTester.run("no-relative-imports", rule, {
-    valid: [
-        {
-            code: 'import moduleA from "moduleA";',
-        },
-        {
-            code: 'import { something } from "@alias/something";',
-        },
-    ],
+  valid: [
+    {
+      code: 'import moduleA from "moduleA";',
+    },
+    {
+      code: 'import { something } from "@alias/something";',
+    },
+  ],
 
-    invalid: [
-        {
-            code: 'import moduleB from "./moduleB";',
-            errors: [{ messageId: "noRelativeImports" }],
-        },
-        {
-            code: 'import moduleC from "./path/moduleC";',
-            errors: [{ messageId: "noRelativeImports" }],
-        },
-    ],
+  invalid: [
+    {
+      code: 'import moduleB from "./moduleB";',
+      errors: [{ messageId: "noRelativeImports" }],
+    },
+    {
+      code: 'import moduleC from "./path/moduleC";',
+      errors: [{ messageId: "noRelativeImports" }],
+    },
+  ],
 });


### PR DESCRIPTION
We introduce the rule [no-relative-parent-imports](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-relative-parent-imports.md) that enforces the usage of absolute imports or aliases, but only if it refers to parent peers.

To completely avoid relative imports, we create a custom rule that simply check the import string.