### PR TITLE
feat: Add require-await rule

### DIFF
--- a/index.cjs
+++ b/index.cjs
@@ -34,11 +34,11 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['*.ts'],
+      files: ["*.ts"],
       rules: {
-        'prefer-const': 'error'
-      }
-    }
+        "prefer-const": "error",
+      },
+    },
   ],
   rules: {
     "@typescript-eslint/consistent-type-definitions": "error",
@@ -65,6 +65,7 @@ module.exports = {
     "no-else-return": ["warn", { allowElseIf: false }],
     "no-unused-vars": "off",
     "prefer-template": "error",
+    "require-await": "error",
   },
   globals: {
     NodeJS: true,


### PR DESCRIPTION
We introduce [require-await](https://eslint.org/docs/latest/rules/require-await) rule, that enforce to await async functions.

It is a bit an opinionated: some projects accepts a lot of of async functions that are not awaited, so it become full of exceptions.

But we do it only in a few strategic places.