### PR TITLE
feat: add new rule explicit-non-void-return-type

### DIFF
--- a/eslint-local-rules.cjs
+++ b/eslint-local-rules.cjs
@@ -3,4 +3,5 @@ module.exports = {
   "use-option-type-wrapper": require("./rules/use-option-type-wrapper"),
   "prefer-object-params": require("./rules/prefer-object-params"),
   "no-relative-imports": require("./rules/no-relative-imports"),
+  "explicit-non-void-return-type": require("./rules/explicit-non-void-return-type"),
 };

--- a/rules/explicit-non-void-return-type.js
+++ b/rules/explicit-non-void-return-type.js
@@ -1,0 +1,103 @@
+const inferReturnType2 = (node, context) => {
+  const sourceCode = context.getSourceCode();
+  const code = sourceCode.getText(node);
+
+  if (node.async) {
+    return "Promise<void>";
+  }
+
+  if (code.includes("Promise<void>")) {
+    return "Promise<void>";
+  }
+
+  if (code.includes("void")) {
+    return "void";
+  }
+
+  return "unknown";
+};
+
+const inferReturnType = (node) => {
+  if (node.async) {
+    if (
+      node.body.type === "BlockStatement" &&
+      !node.body.body.some((statement) => statement.type === "ReturnStatement")
+    ) {
+      return "Promise<void>";
+    }
+    return "Promise<unknown>";
+  }
+
+  if (
+    node.body.type === "BlockStatement" &&
+    !node.body.body.some((statement) => statement.type === "ReturnStatement")
+  ) {
+    return "void";
+  }
+
+  const returnStatements = node.body.body.filter(
+    (statement) => statement.type === "ReturnStatement",
+  );
+
+  if (returnStatements.length > 0) {
+    const returnArgument = returnStatements[0].argument;
+
+    if (returnArgument) {
+      if (returnArgument.type === "Literal") {
+        return typeof returnArgument.value;
+      }
+
+      if (returnArgument.type === "ObjectExpression") {
+        return "{}";
+      }
+    }
+  }
+
+  return "unknown";
+};
+
+const checkReturnType = (node, context) => {
+  const returnType = node.returnType;
+
+  if (!returnType) {
+    const inferredType = inferReturnType(node);
+
+    if (inferredType !== "void" && inferredType !== "Promise<void>") {
+      context.report({
+        node,
+        messageId: "missingReturnType",
+      });
+    }
+  }
+};
+
+module.exports = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Require explicit return types for functions, except when returning void",
+      category: "Best Practices",
+      recommended: false,
+    },
+    messages: {
+      missingReturnType:
+        "Function return type must be explicitly defined unless it returns void.",
+    },
+    schema: [],
+  },
+
+  create(context) {
+    return {
+      FunctionDeclaration(node) {
+        checkReturnType(node, context);
+      },
+      FunctionExpression(node) {
+        checkReturnType(node, context);
+      },
+      ArrowFunctionExpression(node) {
+        checkReturnType(node, context);
+      },
+    };
+  },
+};

--- a/tests/explicit-non-void-return-type.spec.ts
+++ b/tests/explicit-non-void-return-type.spec.ts
@@ -1,0 +1,92 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+
+const rule = require("../rules/explicit-non-void-return-type");
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("explicit-non-void-return-type", rule, {
+  valid: [
+    // Test for implied void returns
+    {
+      code: "function foo(): {}",
+    },
+    {
+      code: "const foo = function() {}",
+    },
+    {
+      code: "const foo = () => {}",
+    },
+    {
+      code: "async function bar() {}",
+    },
+    {
+      code: "const bar = async function() {}",
+    },
+    {
+      code: "const bar = async () => {}",
+    },
+
+    // Test for explicit non-void returns
+    {
+      code: "function foo(): number { return 42; }",
+    },
+    {
+      code: "const foo = function(): string { return 'hello'; }",
+    },
+    {
+      code: "const foo = (): boolean => true",
+    },
+    {
+      code: "async function bar(): Promise<boolean> { return Promise.resolve(true); }",
+    },
+    {
+      code: "const bar = async function(): Promise<number> { return Promise.resolve(42); }",
+    },
+    {
+      code: "const bar = async (): Promise<string> => Promise.resolve('hello');",
+    },
+
+    // Test for explicit void returns
+    {
+      code: "function foo(): void {}",
+    },
+    {
+      code: "const foo = function(): void {}",
+    },
+    {
+      code: "const foo = (): void => {}",
+    },
+    {
+      code: "async function bar(): Promise<void> {}",
+    },
+    {
+      code: "const bar = async function(): Promise<void> {}",
+    },
+    {
+      code: "const bar = async (): Promise<void> => {}",
+    },
+  ],
+
+  invalid: [
+    {
+      code: "function foo() { return 42; }",
+      errors: [{ messageId: "missingReturnType" }],
+    },
+    {
+      code: 'const foo = function() { return "hello"; }',
+      errors: [{ messageId: "missingReturnType" }],
+    },
+    {
+      code: "const foo = () => { return true; }",
+      errors: [{ messageId: "missingReturnType" }],
+    },
+    {
+      code: "const bar = async function() { return 42; }",
+      errors: [{ messageId: "missingReturnType" }],
+    },
+    {
+      code: "async function bar() { return true; }",
+      errors: [{ messageId: "missingReturnType" }],
+    },
+  ],
+});


### PR DESCRIPTION
# Motivation

We want to introduce a new custom rule that enforces the declaration of non-void return types

### Incorrect

```typescript
function foo() { 
  return 42; 
}

const foo = function() { 
  return "hello"; 
}

const foo = () => { 
  return true; 
}

const bar = async function() { 
  return 42; 
}

async function bar() { 
  return true; 
}
```

### Correct

```typescript
function foo(): number { 
  return 42; 
}

const foo = function(): string { 
  return "hello"; 
}

const foo = (): boolean => true;

const bar = async function(): Promise<number> { 
  return Promise.resolve(42); 
}

async function bar(): Promise<boolean> { 
  return Promise.resolve(true); 
}

function foo() { 
  // No return value
}

const foo = function() { 
  // No return value
}

const foo = () => { 
  // No return value
}

const bar = async function() { 
  // No return value
}

async function bar() { 
  // No return value
}
```

