### PR TITLE
feat: Add rules to enforce arrow functions

### DIFF
--- a/index.cjs
+++ b/index.cjs
@@ -21,7 +21,12 @@ module.exports = {
     "prettier",
   ],
   parser: "@typescript-eslint/parser",
-  plugins: ["@typescript-eslint", "eslint-plugin-local-rules", "import"],
+  plugins: [
+    "@typescript-eslint",
+    "eslint-plugin-local-rules",
+    "import",
+    "prefer-arrow",
+  ],
   parserOptions: {
     sourceType: "module",
     ecmaVersion: 2020,
@@ -56,6 +61,7 @@ module.exports = {
     "@typescript-eslint/prefer-reduce-type-parameter": "error",
     "arrow-body-style": ["warn", "as-needed"],
     curly: "error",
+    // "func-style": ["error", "expression"],
     "local-rules/prefer-object-params": "warn",
     "local-rules/use-option-type-wrapper": "warn",
     "import/no-duplicates": ["error", { "prefer-inline": true }],
@@ -65,6 +71,15 @@ module.exports = {
     "no-delete-var": "error",
     "no-else-return": ["warn", { allowElseIf: false }],
     "no-unused-vars": "off",
+    // "prefer-arrow-callback": "error",
+    // "prefer-arrow/prefer-arrow-functions": [
+    //   "error",
+    //   {
+    //     disallowPrototype: true,
+    //     singleReturnOnly: false,
+    //     classPropertiesAllowed: false,
+    //   },
+    // ],
     "prefer-template": "error",
     "require-await": "error",
   },

--- a/index.cjs
+++ b/index.cjs
@@ -61,7 +61,7 @@ module.exports = {
     "@typescript-eslint/prefer-reduce-type-parameter": "error",
     "arrow-body-style": ["warn", "as-needed"],
     curly: "error",
-    // "func-style": ["error", "expression"],
+    "func-style": "error",
     "local-rules/prefer-object-params": "warn",
     "local-rules/use-option-type-wrapper": "warn",
     "import/no-duplicates": ["error", { "prefer-inline": true }],
@@ -71,15 +71,15 @@ module.exports = {
     "no-delete-var": "error",
     "no-else-return": ["warn", { allowElseIf: false }],
     "no-unused-vars": "off",
-    // "prefer-arrow-callback": "error",
-    // "prefer-arrow/prefer-arrow-functions": [
-    //   "error",
-    //   {
-    //     disallowPrototype: true,
-    //     singleReturnOnly: false,
-    //     classPropertiesAllowed: false,
-    //   },
-    // ],
+    "prefer-arrow-callback": "error",
+    "prefer-arrow/prefer-arrow-functions": [
+      "error",
+      {
+        disallowPrototype: true,
+        singleReturnOnly: false,
+        classPropertiesAllowed: false,
+      },
+    ],
     "prefer-template": "error",
     "require-await": "error",
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@dfinity/eslint-config-oisy-wallet",
       "version": "0.0.6",
       "license": "Apache-2.0",
+      "dependencies": {
+        "eslint-plugin-prefer-arrow": "^1.2.3"
+      },
       "devDependencies": {
         "@types/node": "^22.7.3",
         "@typescript-eslint/rule-tester": "^8.7.0",
@@ -2523,6 +2526,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/eslint-plugin-prefer-arrow": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prefer-arrow/-/eslint-plugin-prefer-arrow-1.2.3.tgz",
+      "integrity": "sha512-J9I5PKCOJretVuiZRGvPQxCbllxGAV/viI20JO3LYblAodofBxyMnZAJ+WGeClHgANnSJberTNoFWWjrWKBuXQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=2.0.0"
       }
     },
     "node_modules/eslint-plugin-prettier": {

--- a/package.json
+++ b/package.json
@@ -74,5 +74,8 @@
     "@types/node": "^22.7.3",
     "@typescript-eslint/rule-tester": "^8.7.0",
     "vitest": "^2.1.1"
+  },
+  "dependencies": {
+    "eslint-plugin-prefer-arrow": "^1.2.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@typescript-eslint/eslint-plugin": "^6.20.0",
     "eslint": "^8.57.0",
     "eslint-config-love": "^84.1.0",
+    "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-local-rules": "^3.0.2",
@@ -74,8 +75,5 @@
     "@types/node": "^22.7.3",
     "@typescript-eslint/rule-tester": "^8.7.0",
     "vitest": "^2.1.1"
-  },
-  "dependencies": {
-    "eslint-plugin-prefer-arrow": "^1.2.3"
   }
 }

--- a/rules/explicit-non-void-return-type.cjs
+++ b/rules/explicit-non-void-return-type.cjs
@@ -68,17 +68,15 @@ module.exports = {
     schema: [],
   },
 
-  create(context) {
-    return {
-      FunctionDeclaration(node) {
-        checkReturnType({ node, context });
-      },
-      FunctionExpression(node) {
-        checkReturnType({ node, context });
-      },
-      ArrowFunctionExpression(node) {
-        checkReturnType({ node, context });
-      },
-    };
-  },
+  create: (context) => ({
+    FunctionDeclaration: (node) => {
+      checkReturnType({ node, context });
+    },
+    FunctionExpression: (node) => {
+      checkReturnType({ node, context });
+    },
+    ArrowFunctionExpression: (node) => {
+      checkReturnType({ node, context });
+    },
+  }),
 };

--- a/rules/no-relative-imports.cjs
+++ b/rules/no-relative-imports.cjs
@@ -12,18 +12,16 @@ module.exports = {
     },
     schema: [],
   },
-  create(context) {
-    return {
-      ImportDeclaration(node) {
-        const path = node.source.value;
+  create: (context) => ({
+    ImportDeclaration: (node) => {
+      const path = node.source.value;
 
-        if (path.startsWith("./")) {
-          context.report({
-            node,
-            messageId: "noRelativeImports",
-          });
-        }
-      },
-    };
-  },
+      if (path.startsWith("./")) {
+        context.report({
+          node,
+          messageId: "noRelativeImports",
+        });
+      }
+    },
+  }),
 };

--- a/rules/no-svelte-store-in-api.cjs
+++ b/rules/no-svelte-store-in-api.cjs
@@ -8,22 +8,20 @@ module.exports = {
     },
     schema: [],
   },
-  create(context) {
-    return {
-      ImportDeclaration(node) {
-        const filePath = context.getFilename();
+  create: (context) => ({
+    ImportDeclaration: (node) => {
+      const filePath = context.getFilename();
 
-        const {
-          source: { value },
-        } = node;
+      const {
+        source: { value },
+      } = node;
 
-        if (filePath.includes("/api/") && value === "svelte/store") {
-          context.report({
-            node,
-            message: "Importing 'svelte/store' is not allowed in API modules.",
-          });
-        }
-      },
-    };
-  },
+      if (filePath.includes("/api/") && value === "svelte/store") {
+        context.report({
+          node,
+          message: "Importing 'svelte/store' is not allowed in API modules.",
+        });
+      }
+    },
+  }),
 };

--- a/rules/prefer-object-params.cjs
+++ b/rules/prefer-object-params.cjs
@@ -9,7 +9,7 @@ module.exports = {
     },
     schema: [],
   },
-  create(context) {
+  create: (context) => {
     const checkForMoreThanOneParameter = (node) => {
       const parent = node.parent;
 
@@ -103,13 +103,13 @@ module.exports = {
     };
 
     return {
-      FunctionDeclaration(node) {
+      FunctionDeclaration: (node) => {
         checkForMoreThanOneParameter(node);
       },
-      FunctionExpression(node) {
+      FunctionExpression: (node) => {
         checkForMoreThanOneParameter(node);
       },
-      ArrowFunctionExpression(node) {
+      ArrowFunctionExpression: (node) => {
         checkForMoreThanOneParameter(node);
       },
     };

--- a/rules/use-option-type-wrapper.cjs
+++ b/rules/use-option-type-wrapper.cjs
@@ -13,7 +13,7 @@ module.exports = {
     fixable: "code",
     schema: [],
   },
-  create: function (context) {
+  create: (context) => {
     const checkForOptionType = (node) => {
       if (
         node.typeAnnotation.type === "TSUnionType" &&
@@ -38,12 +38,8 @@ module.exports = {
               data: {
                 type: typeText,
               },
-              fix(fixer) {
-                return fixer.replaceText(
-                  node.typeAnnotation,
-                  `Option<${typeText}>`,
-                );
-              },
+              fix: (fixer) =>
+                fixer.replaceText(node.typeAnnotation, `Option<${typeText}>`),
             });
           } catch (e) {
             // eslint-disable-next-line no-console
@@ -56,10 +52,10 @@ module.exports = {
     };
 
     return {
-      TSTypeAnnotation(node) {
+      TSTypeAnnotation: (node) => {
         checkForOptionType(node);
       },
-      TSTypeAliasDeclaration(node) {
+      TSTypeAliasDeclaration: (node) => {
         checkForOptionType(node);
       },
     };


### PR DESCRIPTION
# Motivation

To further help with enforcing the arrow functions we add two rules and one plugin. This is one of the most suggested combination I found online:

- [prefer-arrow-callback](https://eslint.org/docs/latest/rules/prefer-arrow-callback): this will enforce arrow functions when given as callback to other statements;
- [func-style](https://eslint.org/docs/latest/rules/func-style): the default settings of this rule forces to avoid using declaration statements for functions, for example `function foo() {...}`
- [prefer-arrow](https://www.npmjs.com/package/eslint-plugin-prefer-arrow) plugin: with the configs set by us, the plugin will generally make notice of the usage of `function`.

# Changes

- Installed plugin [prefer-arrow](https://www.npmjs.com/package/eslint-plugin-prefer-arrow).
- Include rules in index file.
- Fix issues raised.

# Tests

The rules raised some new issues on this repo and we fixed them.
