### PR TITLE
feat: add rule consistent-type-imports

### DIFF
--- a/index.cjs
+++ b/index.cjs
@@ -42,6 +42,7 @@ module.exports = {
   ],
   rules: {
     "@typescript-eslint/consistent-type-definitions": "error",
+    '@typescript-eslint/consistent-type-imports': 'error',
     "@typescript-eslint/no-inferrable-types": "error",
     "@typescript-eslint/no-unnecessary-type-assertion": "error",
     "@typescript-eslint/no-unused-vars": [

--- a/index.cjs
+++ b/index.cjs
@@ -42,7 +42,7 @@ module.exports = {
   ],
   rules: {
     "@typescript-eslint/consistent-type-definitions": "error",
-    '@typescript-eslint/consistent-type-imports': 'error',
+    "@typescript-eslint/consistent-type-imports": "error",
     "@typescript-eslint/no-inferrable-types": "error",
     "@typescript-eslint/no-unnecessary-type-assertion": "error",
     "@typescript-eslint/no-unused-vars": [


### PR DESCRIPTION
# Motivation

We include rule [consistent-type-imports](https://typescript-eslint.io/rules/consistent-type-imports/), that, among other things, will change:

```typescript
import { type CustomType } from 'types.ts'
import { type CustomType1, type CustomType2 } from 'types.ts'
```

to 

```typescript
import type { CustomType } from 'types.ts'
import type { CustomType1, CustomType2 } from 'types.ts'
```
