### PR TITLE
feat: disable new eslint rules

### DIFF
--- a/index.cjs
+++ b/index.cjs
@@ -47,7 +47,11 @@ module.exports = {
   ],
   rules: {
     "@typescript-eslint/consistent-type-definitions": "error",
-    "@typescript-eslint/consistent-type-imports": "error",
+
+    // TODO: Disabled for now to allow the migration of ESLint v9 in OISY, as the rule is not yet enforced.
+    // It should also be introduced as an optional rule.
+    // "@typescript-eslint/consistent-type-imports": "error",
+
     "@typescript-eslint/no-inferrable-types": "error",
     "@typescript-eslint/no-unnecessary-type-assertion": "error",
     "@typescript-eslint/no-unused-vars": [
@@ -62,7 +66,11 @@ module.exports = {
     "@typescript-eslint/prefer-reduce-type-parameter": "error",
     "arrow-body-style": ["warn", "as-needed"],
     curly: "error",
-    "func-style": "error",
+
+    // TODO: Disabled for now to allow the migration of ESLint v9 in OISY, as the rule is not yet enforced.
+    // It should also be introduced as an optional rule.
+    // "func-style": "error",
+
     "local-rules/prefer-object-params": "warn",
     "local-rules/use-nullish-checks": "warn",
     "local-rules/use-option-type-wrapper": "warn",
@@ -73,15 +81,22 @@ module.exports = {
     "no-delete-var": "error",
     "no-else-return": ["warn", { allowElseIf: false }],
     "no-unused-vars": "off",
-    "prefer-arrow-callback": "error",
-    "prefer-arrow/prefer-arrow-functions": [
-      "error",
-      {
-        disallowPrototype: true,
-        singleReturnOnly: false,
-        classPropertiesAllowed: false,
-      },
-    ],
+
+    // TODO: Disabled for now to allow the migration of ESLint v9 in OISY, as the rule is not yet enforced.
+    // It should also be introduced as an optional rule.
+    // "prefer-arrow-callback": "error",
+
+    // TODO: Disabled for now to allow the migration of ESLint v9 in OISY, as the rule is not yet enforced.
+    // It should also be introduced as an optional rule.
+    // "prefer-arrow/prefer-arrow-functions": [
+    //   "error",
+    //   {
+    //     disallowPrototype: true,
+    //     singleReturnOnly: false,
+    //     classPropertiesAllowed: false,
+    //   },
+    // ],
+
     "prefer-template": "error",
     "require-await": "error",
   },


### PR DESCRIPTION
# Motivation

We cannot migrate to eslint v9 and introduce new rules at the same time.

# Changes

- Disable all rules introduced since last release.