### PR TITLE
feat: do not enforce precise version of utils and typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "vitest": "^3.0.5"
       },
       "peerDependencies": {
-        "@dfinity/utils": "^2.10.0",
+        "@dfinity/utils": "^2",
         "@eslint/compat": "^1.2.6",
         "@eslint/eslintrc": "^3.2.0",
         "@eslint/js": "^9.20.0",
@@ -32,7 +32,7 @@
         "globals": "^15.15.0",
         "prettier": "^3.5.1",
         "prettier-plugin-organize-imports": "^4.1.0",
-        "typescript": "^5.3.3"
+        "typescript": "^5"
       }
     },
     "node_modules/@dfinity/agent": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "best-practices"
   ],
   "peerDependencies": {
-    "@dfinity/utils": "^2.10.0",
+    "@dfinity/utils": "^2",
     "@eslint/compat": "^1.2.6",
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.20.0",
@@ -75,7 +75,7 @@
     "globals": "^15.15.0",
     "prettier": "^3.5.1",
     "prettier-plugin-organize-imports": "^4.1.0",
-    "typescript": "^5.3.3"
+    "typescript": "^5"
   },
   "devDependencies": {
     "@types/node": "^22.7.3",


### PR DESCRIPTION
# Motivation

We don't want to force consumer to use explicitely `@dfinity/utils` or `typescript` version x.y.z. The version should not be given by eslint but by the need of features.
