### PR TITLE
feat: add Svelte rules shorthand-attribute and shorthand-directive

### DIFF
--- a/svelte.mjs
+++ b/svelte.mjs
@@ -13,6 +13,7 @@ export default [
   ...svelte.configs["flat/recommended"],
   ...svelte.configs["flat/prettier"],
   languageOptions([".svelte"]),
+
   {
     files: ["**/*.svelte"],
     languageOptions: {
@@ -26,7 +27,6 @@ export default [
 
   {
     files: ["**/*.svelte"],
-
     rules: {
       "import/order": [
         "error",
@@ -38,6 +38,14 @@ export default [
       ],
     },
   },
+
+  {
+    rules:{
+      "svelte/shorthand-attribute": ["error"],
+      "svelte/shorthand-directive": ["error"],
+    }
+  },
+
   {
     files: ["scripts/**/*.mjs", "scripts/**/*.ts"],
 

--- a/svelte.mjs
+++ b/svelte.mjs
@@ -40,10 +40,10 @@ export default [
   },
 
   {
-    rules:{
+    rules: {
       "svelte/shorthand-attribute": ["error"],
       "svelte/shorthand-directive": ["error"],
-    }
+    },
   },
 
   {


### PR DESCRIPTION
# Motivation

We would like to include Svelte lint rules [shorthand-attribute](https://sveltejs.github.io/eslint-plugin-svelte/rules/shorthand-attribute/) and [shorthand-directive](https://sveltejs.github.io/eslint-plugin-svelte/rules/shorthand-directive/) to keep the code a bit cleaner: they enforce the usage of shorthand syntax, for example:

```svelte
<!-- ✓ GOOD -->
<button {disabled}>...</button>

<!-- ✗ BAD -->
<button disabled={disabled}>...</button>
```