### PR TITLE
feat: add Svelte check rule spaced-html-comment

### DIFF
--- a/svelte.mjs
+++ b/svelte.mjs
@@ -43,6 +43,7 @@ export default [
     rules: {
       "svelte/shorthand-attribute": ["error"],
       "svelte/shorthand-directive": ["error"],
+      'svelte/spaced-html-comment': ['error'],
     },
   },
 

--- a/svelte.mjs
+++ b/svelte.mjs
@@ -43,7 +43,7 @@ export default [
     rules: {
       "svelte/shorthand-attribute": ["error"],
       "svelte/shorthand-directive": ["error"],
-      'svelte/spaced-html-comment': ['error'],
+      "svelte/spaced-html-comment": ["error"],
     },
   },
 


### PR DESCRIPTION
# Motivation

Just to keep it "prettier", we add Svelte rule [spaced-html-comment](https://sveltejs.github.io/eslint-plugin-svelte/rules/spaced-html-comment/).
