### PR TITLE
feat: add Svelte check rule no-extra-reactive-curlies

### DIFF
--- a/svelte.mjs
+++ b/svelte.mjs
@@ -41,6 +41,7 @@ export default [
 
   {
     rules: {
+      'svelte/no-extra-reactive-curlies': ['error'],
       "svelte/shorthand-attribute": ["error"],
       "svelte/shorthand-directive": ["error"],
       "svelte/spaced-html-comment": ["error"],

--- a/svelte.mjs
+++ b/svelte.mjs
@@ -41,7 +41,7 @@ export default [
 
   {
     rules: {
-      'svelte/no-extra-reactive-curlies': ['error'],
+      "svelte/no-extra-reactive-curlies": ["error"],
       "svelte/shorthand-attribute": ["error"],
       "svelte/shorthand-directive": ["error"],
       "svelte/spaced-html-comment": ["error"],


### PR DESCRIPTION
# Motivation

Maybe opinionated, but I would like to add Svelte check rule [no-extra-reactive-curlies](https://sveltejs.github.io/eslint-plugin-svelte/rules/no-extra-reactive-curlies/) that disallows wrapping single reactive statements in curly braces.