### PR TITLE
feat: add rule object-shorthand

### DIFF
--- a/configs/eslint.rules.mjs
+++ b/configs/eslint.rules.mjs
@@ -65,6 +65,7 @@ export const eslintRules = [
       "local-rules/use-option-type-wrapper": "warn",
       "import/no-duplicates": ["error", { "prefer-inline": true }],
       "import/no-relative-parent-imports": "error",
+      "object-shorthand": "error",
       "no-console": ["error", { allow: ["error", "warn"] }],
       "no-continue": "warn",
       "no-delete-var": "error",


### PR DESCRIPTION
# Motivation

I would like to introduce the eslint rule [object-shorthand](https://eslint.org/docs/latest/rules/object-shorthand) that requires method and property shorthand syntax for object literals.