### PR TITLE
feat: add Svelte check rule block-lang

### DIFF
--- a/svelte.mjs
+++ b/svelte.mjs
@@ -41,6 +41,15 @@ export default [
 
   {
     rules: {
+      "svelte/block-lang": [
+        "error",
+        {
+          enforceScriptPresent: true,
+          enforceStylePresent: true,
+          script: ["ts"],
+          style: ["scss", "postcss"],
+        },
+      ],
       "svelte/no-extra-reactive-curlies": ["error"],
       "svelte/shorthand-attribute": ["error"],
       "svelte/shorthand-directive": ["error"],


### PR DESCRIPTION
# Motivation

Maybe opinionated, but I think the language of the blocks of a Svelte component should be explicit. So, with this PR, we introduce the Svelte rule [block-lang](https://sveltejs.github.io/eslint-plugin-svelte/rules/block-lang/) that disallows the use of languages other than those specified in the configuration for the lang attribute of <script> and <style> blocks.

We set it to be always present in both blocks as:
- `script`: Typescript
- `style`: Sass and Postcss