### PR TITLE
docs: add instructions to disable or override rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,32 @@ module.exports = require("@dfinity/eslint-config-oisy-wallet/eslint-local-rules"
 > [!NOTE]
 > This is necessary because the `eslint-plugin-local-rules` plugin we use for custom rules requires a file located at the root and does not offer any customizable location option.
 
+
+## 🔧 Overriding or Disabling Rules
+
+You can override or disable any of the rules provided by this configuration — including custom **local rules** — just like you would with any ESLint config.
+
+In your `.eslintrc.js`, simply add a `rules` section:
+
+```javascript
+module.exports = {
+    extends: ["@dfinity/eslint-config-oisy-wallet/svelte"],
+    rules: {
+        // Disable a built-in rule
+        "no-console": "off",
+
+        // Disable a local custom rule
+        "local/use-nullish-checks": "off",
+
+        // Customize severity or options
+        "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }],
+    },
+};
+```
+
+Note: To override local rules, make sure you have the `eslint-local-rules.cjs` file at the root as described above.
+
+
 ## 🛠️ TypeScript Support
 
 If your project uses TypeScript, make sure you have a `tsconfig.json` file in your project root.


### PR DESCRIPTION
# Motivation

It is useful to document how to override or disable rules that the consumer may want to.