### PR TITLE
feat: rule svelte/block-lang should allow for missing blocks

### DIFF
--- a/svelte.mjs
+++ b/svelte.mjs
@@ -44,8 +44,8 @@ export default [
       "svelte/block-lang": [
         "error",
         {
-          enforceScriptPresent: true,
-          enforceStylePresent: true,
+          enforceScriptPresent: false,
+          enforceStylePresent: false,
           script: ["ts"],
           style: ["scss", "postcss"],
         },


### PR DESCRIPTION
# Motivation

Rule `svelte/block-lang` is too restrictive: we can allow to have missing blocks.
