### PR TITLE
feat: add option fixStyle to rule @typescript-eslint/consistent-type-imports

### DIFF
--- a/configs/eslint.rules.mjs
+++ b/configs/eslint.rules.mjs
@@ -29,7 +29,12 @@ export const eslintRules = [
     },
 
     rules: {
-      "@typescript-eslint/consistent-type-definitions": "error",
+      "@typescript-eslint/consistent-type-imports": [
+        "error",
+        {
+          fixStyle: "separate-type-imports"
+        },
+      ],
 
       // TODO: Disabled for now to allow the migration of ESLint v9 in OISY, as the rule is not yet enforced.
       // It should also be introduced as an optional rule.


### PR DESCRIPTION
# Motivation

I would like to have type always after import (for example `import type { TypeA }` instead of `import { type TypeA }`). So we set option [fixStyle](https://typescript-eslint.io/rules/consistent-type-imports/#fixstyle) of rule `@typescript-eslint/consistent-type-imports` to `separate-type-imports`.