### PR TITLE
feat: add option newlines-between to rule import/order

### DIFF
--- a/svelte.mjs
+++ b/svelte.mjs
@@ -34,6 +34,7 @@ export default [
           alphabetize: {
             order: "asc",
           },
+          "newlines-between": "never",
         },
       ],
     },


### PR DESCRIPTION
# Motivation

Preferably there are no unnecessary newlines between imports. So we set option [newlines-between](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md#newlines-between) of rule `import/order` to `never`.