### PR TITLE
refactor: use plugins-rules syntax for vitest linter

### DIFF
--- a/vitest.mjs
+++ b/vitest.mjs
@@ -4,6 +4,6 @@ import { eslintCoreConfig } from "./configs/eslint.core.mjs";
 
 export default [
   ...eslintCoreConfig,
-  ...vitest.configs.recommended,
+  { plugins: { vitest }, rules: { ...vitest.configs.recommended.rules } },
   languageOptions(),
 ];


### PR DESCRIPTION
# Motivation

According to [documentation](https://github.com/vitest-dev/eslint-plugin-vitest?tab=readme-ov-file#usage), and in preparation to add more rules to the `vitest` linter, we refactor how we import the vitest plugin rules, using the syntax plugins-rules, that apparently is the only structure that works if we want to add/remove more rules as single options.

For example:

```typescript
{
    plugins: {      vitest    },
    rules: {
      ...vitest.configs.recommended.rules, 
      "vitest/valid-expect-in-promise": ["error"]
    },
  },
```
