### PR TITLE
feat: add vitest rule prefer-hooks-on-top

### DIFF
--- a/vitest.mjs
+++ b/vitest.mjs
@@ -4,6 +4,13 @@ import { eslintCoreConfig } from "./configs/eslint.core.mjs";
 
 export default [
   ...eslintCoreConfig,
-  { plugins: { vitest }, rules: { ...vitest.configs.recommended.rules } },
+  {
+    plugins: { vitest },
+    rules: {
+      ...vitest.configs.recommended.rules,
+
+      "vitest/prefer-hooks-on-top": ["error"],
+    },
+  },
   languageOptions(),
 ];


### PR DESCRIPTION
# Motivation

To have a more organized test structure, we include vitest rule [prefer-hooks-on-top](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-hooks-on-top.md) that enforces hooks to be before the tests..

