### PR TITLE
feat: add vitest rule prefer-hooks-in-order

### DIFF
--- a/vitest.mjs
+++ b/vitest.mjs
@@ -4,6 +4,13 @@ import { eslintCoreConfig } from "./configs/eslint.core.mjs";
 
 export default [
   ...eslintCoreConfig,
-  { plugins: { vitest }, rules: { ...vitest.configs.recommended.rules } },
+  {
+    plugins: { vitest },
+    rules: {
+      ...vitest.configs.recommended.rules,
+
+      "vitest/prefer-hooks-in-order": ["error"],
+    },
+  },
   languageOptions(),
 ];


### PR DESCRIPTION
# Motivation

To have a more organized test structure, we include vitest rule [prefer-hooks-in-order](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-hooks-in-order.md) that enforces a specific order of the hooks: 

```typescript
  // consistent order of hooks
  ['beforeAll', 'beforeEach', 'afterEach', 'afterAll']
```