### PR TITLE
feat: add vitest rule padding-around-all

### DIFF
--- a/vitest.mjs
+++ b/vitest.mjs
@@ -4,6 +4,13 @@ import { eslintCoreConfig } from "./configs/eslint.core.mjs";
 
 export default [
   ...eslintCoreConfig,
-  { plugins: { vitest }, rules: { ...vitest.configs.recommended.rules } },
+  {
+    plugins: { vitest },
+    rules: {
+      ...vitest.configs.recommended.rules,
+
+      "vitest/padding-around-all": ["error"],
+    },
+  },
   languageOptions(),
 ];


### PR DESCRIPTION
# Motivation

To have a more organized test structure, we include vitest rule [padding-around-all](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/padding-around-all.md) that enforces padding around hooks and test statements.