### PR TITLE
refactor: remove TODO and default option for rule consistent-type-imports

### DIFF
--- a/configs/eslint.rules.mjs
+++ b/configs/eslint.rules.mjs
@@ -29,17 +29,7 @@ export const eslintRules = [
     },
 
     rules: {
-      "@typescript-eslint/consistent-type-imports": [
-        "error",
-        {
-          fixStyle: "separate-type-imports",
-        },
-      ],
-
-      // TODO: Disabled for now to allow the migration of ESLint v9 in OISY, as the rule is not yet enforced.
-      // It should also be introduced as an optional rule.
-      // "@typescript-eslint/consistent-type-imports": "error",
-
+      "@typescript-eslint/consistent-type-imports": "error",
       "@typescript-eslint/no-inferrable-types": "error",
       "@typescript-eslint/no-unnecessary-type-assertion": "error",
 


### PR DESCRIPTION
# Motivation

The rule [@typescript-eslint/consistent-type-imports](https://typescript-eslint.io/rules/consistent-type-imports/) has by default option `fixStyle: "separate-type-imports"` so we can remove it.

Furthermore there was a leftover TODO related to this rule, we can remove it too.
