### PR TITLE
feat: add vitest rule no-duplicate-hooks

### DIFF
--- a/vitest.mjs
+++ b/vitest.mjs
@@ -4,6 +4,13 @@ import { eslintCoreConfig } from "./configs/eslint.core.mjs";
 
 export default [
   ...eslintCoreConfig,
-  { plugins: { vitest }, rules: { ...vitest.configs.recommended.rules } },
+  {
+    plugins: { vitest },
+    rules: {
+      ...vitest.configs.recommended.rules,
+
+      "vitest/no-duplicate-hooks": ["error"],
+    },
+  },
   languageOptions(),
 ];


### PR DESCRIPTION
# Motivation

To have a more organized test structure, we include vitest rule [no-duplicate-hooks](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-duplicate-hooks.md) that enforces avoiding duplicated hooks.

