### PR TITLE
feat: add vitest rule prefer-to-have-length

### DIFF
--- a/vitest.mjs
+++ b/vitest.mjs
@@ -13,6 +13,7 @@ export default [
       "vitest/padding-around-all": ["error"],
       "vitest/prefer-hooks-in-order": ["error"],
       "vitest/prefer-hooks-on-top": ["error"],
+      "vitest/prefer-to-have-length": ["error"],
     },
   },
   languageOptions(),


### PR DESCRIPTION
# Motivation

To have more consistency in the tests, we include vitest rule [prefer-to-have-length](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-to-have-length.md) :

```ts
// bad
expect(files.length).toStrictEqual(1);

// good
expect(files).toHaveLength(1);
```

