### PR TITLE
feat: add vitest rule prefer-to-be-object

### DIFF
--- a/vitest.mjs
+++ b/vitest.mjs
@@ -13,6 +13,7 @@ export default [
       "vitest/padding-around-all": ["error"],
       "vitest/prefer-hooks-in-order": ["error"],
       "vitest/prefer-hooks-on-top": ["error"],
+      "vitest/prefer-to-be-object": ["error"],
     },
   },
   languageOptions(),


### PR DESCRIPTION
# Motivation

To have more consistency in the tests, we include vitest rules [prefer-to-be-object](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-to-be-object.md):

```ts
// bad
expectTypeOf({}).not.toBeInstanceOf(Object);

// good
expectTypeOf({}).not.toBeObject();
```