### PR TITLE
feat: add rule `no-import-type-side-effects`

### DIFF
--- a/configs/eslint.rules.mjs
+++ b/configs/eslint.rules.mjs
@@ -30,6 +30,7 @@ export const eslintRules = [
 
     rules: {
       "@typescript-eslint/consistent-type-imports": "error",
+      "@typescript-eslint/no-import-type-side-effects": "error",
       "@typescript-eslint/no-inferrable-types": "error",
       "@typescript-eslint/no-unnecessary-type-assertion": "error",
 


### PR DESCRIPTION
# Motivation

We had rule  [@typescript-eslint/no-import-type-side-effects](https://typescript-eslint.io/rules/no-import-type-side-effects/) that:

> Enforce the use of top-level import type qualifier when an import only has specifiers with inline type qualifiers.
