### PR TITLE
feat: add vitest rule `prefer-each`

### DIFF
--- a/vitest.mjs
+++ b/vitest.mjs
@@ -13,6 +13,7 @@ export default [
       "vitest/no-duplicate-hooks": ["error"],
       "vitest/padding-around-all": ["error"],
       "vitest/prefer-comparison-matcher": ["error"],
+      "vitest/prefer-each": ["error"],
       "vitest/prefer-hooks-in-order": ["error"],
       "vitest/prefer-hooks-on-top": ["error"],
       "vitest/prefer-to-be-falsy": ["error"],


### PR DESCRIPTION
# Motivation

To have more consistency in the tests, we include vitest rules [prefer-each](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-each.md) that enforce the use of `.each` loop instead of `for` loops.