### PR TITLE
feat: re-instate rules `func-style`, `prefer-arrow-callback` and `prefer-arrow-functions`

### DIFF
--- a/configs/eslint.rules.mjs
+++ b/configs/eslint.rules.mjs
@@ -69,16 +69,14 @@ export const eslintRules = [
       "no-useless-rename": "error",
       "prefer-arrow-callback": "error",
 
-      // TODO: Disabled for now to allow the migration of ESLint v9 in OISY, as the rule is not yet enforced.
-      // It should also be introduced as an optional rule.
-      // "prefer-arrow/prefer-arrow-functions": [
-      // "error",
-      // {
-      //  disallowPrototype: true,
-      //  singleReturnOnly: false,
-      //  classPropertiesAllowed: false,
-      // },
-      // ],
+      "prefer-arrow/prefer-arrow-functions": [
+        "error",
+        {
+          disallowPrototype: true,
+          singleReturnOnly: false,
+          classPropertiesAllowed: false,
+        },
+      ],
 
       "prefer-template": "error",
       "require-await": "error",

--- a/configs/eslint.rules.mjs
+++ b/configs/eslint.rules.mjs
@@ -33,7 +33,6 @@ export const eslintRules = [
       "@typescript-eslint/no-import-type-side-effects": "error",
       "@typescript-eslint/no-inferrable-types": "error",
       "@typescript-eslint/no-unnecessary-type-assertion": "error",
-
       "@typescript-eslint/no-unused-vars": [
         "warn",
         {
@@ -42,15 +41,12 @@ export const eslintRules = [
           caughtErrorsIgnorePattern: "^_",
         },
       ],
-
       "@typescript-eslint/prefer-nullish-coalescing": "error",
       "@typescript-eslint/prefer-reduce-type-parameter": "error",
+
       "arrow-body-style": ["warn", "as-needed"],
       curly: "error",
-
-      // TODO: Disabled for now to allow the migration of ESLint v9 in OISY, as the rule is not yet enforced.
-      // It should also be introduced as an optional rule.
-      // "func-style": "error",
+      "func-style": "error",
 
       "local-rules/prefer-object-params": "warn",
 
@@ -59,8 +55,10 @@ export const eslintRules = [
       // "local-rules/use-nullish-checks": "warn",
 
       "local-rules/use-option-type-wrapper": "warn",
+
       "import/no-duplicates": ["error", { "prefer-inline": true }],
       "import/no-relative-parent-imports": "error",
+
       "object-shorthand": "error",
       "prefer-destructuring": "error",
       "no-console": ["error", { allow: ["error", "warn"] }],
@@ -69,10 +67,7 @@ export const eslintRules = [
       "no-else-return": ["warn", { allowElseIf: false }],
       "no-unused-vars": "off",
       "no-useless-rename": "error",
-
-      // TODO: Disabled for now to allow the migration of ESLint v9 in OISY, as the rule is not yet enforced.
-      // It should also be introduced as an optional rule.
-      // "prefer-arrow-callback": "error",
+      "prefer-arrow-callback": "error",
 
       // TODO: Disabled for now to allow the migration of ESLint v9 in OISY, as the rule is not yet enforced.
       // It should also be introduced as an optional rule.


### PR DESCRIPTION
# Motivation

We can re-instate rules `func-style`, `prefer-arrow-callback`, and `prefer-arrow-functions`: I tested them all in OISY and it was smoothly handled.
