### PR TITLE
feat: add vitest rule `no-standalone-expect`

### DIFF
--- a/vitest.mjs
+++ b/vitest.mjs
@@ -11,6 +11,7 @@ export default [
 
       "vitest/no-alias-methods": ["error"],
       "vitest/no-duplicate-hooks": ["error"],
+      "vitest/no-standalone-expect": ["error"],
       "vitest/padding-around-all": ["error"],
       "vitest/prefer-comparison-matcher": ["error"],
       "vitest/prefer-each": ["error"],


### PR DESCRIPTION
# Motivation

To have more consistency in the tests, we include vitest rules [no-standalone-expect](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-standalone-expect.md) that aims to prevent the use of `expect` outside of `it` or `test` blocks.
