### PR TITLE
feat: add vitest rule `prefer-equality-matcher`

### DIFF
--- a/vitest.mjs
+++ b/vitest.mjs
@@ -14,6 +14,7 @@ export default [
       "vitest/padding-around-all": ["error"],
       "vitest/prefer-comparison-matcher": ["error"],
       "vitest/prefer-each": ["error"],
+      "vitest/prefer-equality-matcher": ["error"],
       "vitest/prefer-hooks-in-order": ["error"],
       "vitest/prefer-hooks-on-top": ["error"],
       "vitest/prefer-to-be-falsy": ["error"],


### PR DESCRIPTION
# Motivation

To have more consistency in the tests, we include vitest rules [prefer-equality-matcher](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-equality-matcher.md) that aims to enforce the use of the built-in equality matchers.

```ts
 // bad 
  expect(1 == 1).toBe(1)
  
 // bad
  expect(1).toEqual(1)
```