### PR TITLE
feat: add vitest rule `require-top-level-describe`

### DIFF
--- a/vitest.mjs
+++ b/vitest.mjs
@@ -21,6 +21,7 @@ export default [
       "vitest/prefer-to-be-truthy": ["error"],
       "vitest/prefer-to-contain": ["error"],
       "vitest/prefer-to-have-length": ["error"],
+      "vitest/require-top-level-describe": ["error"],
     },
   },
   languageOptions(),


### PR DESCRIPTION
# Motivation

To have more consistency in the tests, we include vitest rules [require-top-level-describe](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/require-top-level-describe.md) that warns if a test case or a hook is not located in a top-level `describe` block.