### PR TITLE
fix: add `some` among the exceptions of rule `prefer-object-params`

### DIFF
--- a/rules/prefer-object-params.cjs
+++ b/rules/prefer-object-params.cjs
@@ -43,7 +43,7 @@ module.exports = {
           "reduce",
           "reduceRight",
           "slice",
-          'some',
+          "some",
           "splice",
           "toLocaleString",
           "toSpliced",

--- a/rules/prefer-object-params.cjs
+++ b/rules/prefer-object-params.cjs
@@ -43,6 +43,7 @@ module.exports = {
           "reduce",
           "reduceRight",
           "slice",
+          'some',
           "splice",
           "toLocaleString",
           "toSpliced",


### PR DESCRIPTION
# Motivation

Loop function `some` is missing among the exceptions of rule `prefer-object-params`.
