### PR TITLE
feat: add TS rule `no-unnecessary-condition`

### DIFF
--- a/configs/eslint.rules.mjs
+++ b/configs/eslint.rules.mjs
@@ -32,6 +32,7 @@ export const eslintRules = [
       "@typescript-eslint/consistent-type-imports": "error",
       "@typescript-eslint/no-import-type-side-effects": "error",
       "@typescript-eslint/no-inferrable-types": "error",
+      "@typescript-eslint/no-unnecessary-condition": "error",
       "@typescript-eslint/no-unnecessary-type-assertion": "error",
       "@typescript-eslint/no-unused-vars": [
         "warn",


### PR DESCRIPTION
# Motivation

We add TS lint rule [no-unnecessary-condition](https://typescript-eslint.io/rules/no-unnecessary-condition/) that warns about unnecessary coalescing in objects.
