### PR TITLE
feat: add TS rule `strict-boolean-expressions`

### DIFF
--- a/configs/eslint.rules.mjs
+++ b/configs/eslint.rules.mjs
@@ -43,6 +43,7 @@ export const eslintRules = [
       ],
       "@typescript-eslint/prefer-nullish-coalescing": "error",
       "@typescript-eslint/prefer-reduce-type-parameter": "error",
+      "@typescript-eslint/strict-boolean-expressions": "error",
 
       "arrow-body-style": ["warn", "as-needed"],
       curly: "error",


### PR DESCRIPTION
# Motivation

Sometimes, when we have an IF condition using a boolean, it may happen that the boolean can be nullish (`boolean | undefined | nullish`).

In this case it is useful to distinguish what should the condition be, so we introduce rule [strict-boolean-expressions](https://typescript-eslint.io/rules/strict-boolean-expressions/) that enforces it.
