### PR TITLE
feat(frontend): re-introduce rule consistent-type-definitions

### DIFF
--- a/configs/eslint.rules.mjs
+++ b/configs/eslint.rules.mjs
@@ -29,6 +29,7 @@ export const eslintRules = [
     },
 
     rules: {
+      "@typescript-eslint/consistent-type-definitions": "error",
       "@typescript-eslint/consistent-type-imports": "error",
       "@typescript-eslint/no-import-type-side-effects": "error",
       "@typescript-eslint/no-inferrable-types": "error",


### PR DESCRIPTION
# Motivation

In PR https://github.com/dfinity/eslint-config-oisy-wallet/pull/72 , I mistakenly removed rule [consistent-type-definitions](https://typescript-eslint.io/rules/consistent-type-definitions/) while rebasing...