### PR TITLE
feat: add vitest rule `prefer-mock-promise-shorthand`

### DIFF
--- a/vitest.mjs
+++ b/vitest.mjs
@@ -19,6 +19,7 @@ export default [
       "vitest/prefer-expect-resolves": ["error"],
       "vitest/prefer-hooks-in-order": ["error"],
       "vitest/prefer-hooks-on-top": ["error"],
+      "vitest/prefer-mock-promise-shorthand": ["error"],
       "vitest/prefer-to-be-falsy": ["error"],
       "vitest/prefer-to-be-object": ["error"],
       "vitest/prefer-to-be-truthy": ["error"],


### PR DESCRIPTION
# Motivation

I would like to propose the vitest rule [prefer-mock-promise-shorthand](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-mock-promise-shorthand.md):

```ts
// bad
vi.fn().mockReturnValue(Promise.reject(42))
vi.fn().mockImplementation(() => Promise.resolve(42))

// good
vi.fn().mockRejectedValue(42)
vi.fn().mockResolvedValue(42)
```
