### PR TITLE
feat: add vitest rule `prefer-todo`

### DIFF
--- a/vitest.mjs
+++ b/vitest.mjs
@@ -24,6 +24,7 @@ export default [
       "vitest/prefer-to-be-truthy": ["error"],
       "vitest/prefer-to-contain": ["error"],
       "vitest/prefer-to-have-length": ["error"],
+      "vitest/prefer-todo": ["error"],
       "vitest/require-top-level-describe": ["error"],
     },
   },


### PR DESCRIPTION
# Motivation

To be more explicit and better monitor missing tests, we add vitest rule [prefer-todo](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-todo.md) that enforces the use of `test.todo` instead of

```ts
test('foo');
test('foo', () => {})
test.skip('foo', () => {})
```