### PR TITLE
feat: Add Svelte rule `require-event-prefix`

### DIFF
--- a/svelte.mjs
+++ b/svelte.mjs
@@ -52,6 +52,7 @@ export default [
         },
       ],
       "svelte/no-extra-reactive-curlies": ["error"],
+      "svelte/require-event-prefix": ["error"],
       "svelte/shorthand-attribute": ["error"],
       "svelte/shorthand-directive": ["error"],
       "svelte/spaced-html-comment": ["error"],


### PR DESCRIPTION
# Motivation

To be more consistent on Svelte 5, we enforce rule [require-event-prefix](https://sveltejs.github.io/eslint-plugin-svelte/rules/require-event-prefix/) that normalizes components event-functions.
