### PR TITLE
chore: use Node v22 in CI

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -7,7 +7,7 @@ runs:
   steps:
     - uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: 22
         registry-url: "https://registry.npmjs.org"
     - name: Install dependencies
       shell: bash


### PR DESCRIPTION
# Motivation

We want to use Node LTS.

This might also resolve the publishing issue we had in https://github.com/dfinity/eslint-config-oisy-wallet/actions/runs/15063303915/job/42342507748
