### PR TITLE
devops: Update Node to v22 for workflows

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -7,7 +7,7 @@ runs:
   steps:
     - uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: 22
         registry-url: "https://registry.npmjs.org"
     - name: Install dependencies
       shell: bash


### PR DESCRIPTION
# Motivation

Similar to PR https://github.com/dfinity/ic-js/pull/927, we bump the Node version used in the CI workflows.
