### PR TITLE
fix: Remove TS rule `no-unnecessary-condition`

### DIFF
--- a/configs/eslint.rules.mjs
+++ b/configs/eslint.rules.mjs
@@ -34,7 +34,6 @@ export const eslintRules = [
       "@typescript-eslint/no-import-type-side-effects": "error",
       "@typescript-eslint/no-inferrable-types": "error",
       "@typescript-eslint/no-non-null-asserted-nullish-coalescing": "error",
-      "@typescript-eslint/no-unnecessary-condition": "error",
       "@typescript-eslint/no-unnecessary-type-assertion": "error",
       "@typescript-eslint/no-unused-vars": [
         "warn",


### PR DESCRIPTION
# Motivation

I misjudged rule [no-unnecessary-condition](https://typescript-eslint.io/rules/no-unnecessary-condition): there is a known limitation that returns false positive for [possibly-undefined indexed access](https://typescript-eslint.io/rules/no-unnecessary-condition/#possibly-undefined-indexed-access).

So, for example, the snippet

```ts
const randomMap: Record<number, { value: string }> = {}
randomMap?.[123].value
```

will raise a lint warning. While, if we remove the coalescing

```ts
const randomMap: Record<number, { value: string }> = {}
randomMap[123].value
```

it will not raise a lint warning, but it will fail at runtime.

Since this is a very common use-case, my suggestion is to remove the rule.