### PR TITLE
chore: Bump version for release v0.1.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/eslint-config-oisy-wallet",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/eslint-config-oisy-wallet",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.13.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/eslint-config-oisy-wallet",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "license": "Apache-2.0",
   "description": "Shared ESLint configurations from the Oisy Wallet team",
   "repository": {


### PR DESCRIPTION
# Motivation

We want to release a patch v0.1.12 to include fix https://github.com/dfinity/eslint-config-oisy-wallet/pull/121
