### PR TITLE
feat: Add Svelte rule `prefer-const`

### DIFF
--- a/svelte.mjs
+++ b/svelte.mjs
@@ -52,6 +52,12 @@ export default [
         },
       ],
       "svelte/no-extra-reactive-curlies": ["error"],
+      "svelte/prefer-const": [
+        "error",
+        {
+          excludedRunes: ["$props", "$derived", "$state"],
+        },
+      ],
       "svelte/require-event-prefix": ["error"],
       "svelte/shorthand-attribute": ["error"],
       "svelte/shorthand-directive": ["error"],


### PR DESCRIPTION
# Motivation

We introduce Svelte lint rule [prefer-const](https://sveltejs.github.io/eslint-plugin-svelte/rules/prefer-const/), that warns about unnecessary mutable variables in Svelte components.

In Svelte 5, some variables are defined using runes. By default the runes excluded by this lint rule are `$props` and `$derived`.

However, we decided (see [thread](https://github.com/dfinity/gix-components/pull/631#discussion_r2091543928)) to leave mutable variables when they are defined by `$state`. So we exclude it from the rule too.