### PR TITLE
feat: Add rule `no-non-null-assertion`

### DIFF
--- a/configs/eslint.rules.mjs
+++ b/configs/eslint.rules.mjs
@@ -34,6 +34,7 @@ export const eslintRules = [
       "@typescript-eslint/no-import-type-side-effects": "error",
       "@typescript-eslint/no-inferrable-types": "error",
       "@typescript-eslint/no-non-null-asserted-nullish-coalescing": "error",
+      "@typescript-eslint/no-non-null-assertion": "error",
       "@typescript-eslint/no-unnecessary-type-assertion": "error",
       "@typescript-eslint/no-unused-vars": [
         "warn",


### PR DESCRIPTION
# Motivation

We would like to avoid the usage of the non-null assertion `!` in the code, so we introduce rule [no-non-null-assertion](https://typescript-eslint.io/rules/no-non-null-assertion/).