### PR TITLE
feat: accept peer dfinity utils as of v2 not only v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "vitest": "^3.0.7"
       },
       "peerDependencies": {
-        "@dfinity/utils": "^2",
+        "@dfinity/utils": ">=2",
         "@eslint/compat": "^1.2.6",
         "@eslint/eslintrc": "^3.2.0",
         "@eslint/js": "^9.20.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "best-practices"
   ],
   "peerDependencies": {
-    "@dfinity/utils": "^2",
+    "@dfinity/utils": ">=2",
     "@eslint/compat": "^1.2.6",
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.20.0",


### PR DESCRIPTION
# Motivation

I have trouble install ic-js and agent-js beta because the linter requires utils v2. I think we can makes it accept anything above.

# Notes

Potentially we can even close to accept * because isNullish etc. were introduced in utils [v0.0.13](https://github.com/dfinity/ic-js/releases/tag/v0.15.0) but, let's try first like this.

# Changes

- Accept `>=` instead of `^`

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->
