### PR TITLE
build: accept any utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "vitest": "^3.0.7"
       },
       "peerDependencies": {
-        "@dfinity/utils": ">=2",
+        "@dfinity/utils": "*",
         "@eslint/compat": "^1.2.6",
         "@eslint/eslintrc": "^3.2.0",
         "@eslint/js": "^9.20.0",
@@ -37,9 +37,9 @@
       }
     },
     "node_modules/@dfinity/agent": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.3.0.tgz",
-      "integrity": "sha512-f/eNydwuOunTKRcZAW1RxrcmKyb1AFqZM/ysJJaqFCX9Y+men9NoBTeuUI23XKUp9YeDb9yinGyAlYqjb6VMPw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.4.1.tgz",
+      "integrity": "sha512-IczFFOUDGfMTdQ83yiCvGtvHr1IIB80lWBP0ZYRLogs6NVt8t6HYcMlu1sgT+9VivhT7iwX4pktPFxxOkO3COw==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -51,24 +51,24 @@
         "simple-cbor": "^0.4.1"
       },
       "peerDependencies": {
-        "@dfinity/candid": "^2.3.0",
-        "@dfinity/principal": "^2.3.0"
+        "@dfinity/candid": "^2.4.1",
+        "@dfinity/principal": "^2.4.1"
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.3.0.tgz",
-      "integrity": "sha512-Xzj3EWfwaVZy90jq6WBRP4Cyqo93r3g8tvBea8W8PN3I4W6KcN2/9ZJaBhT3Y4NP+p2w4ZO6aJ+qp9xH990aYw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.4.1.tgz",
+      "integrity": "sha512-kOaIKfhR2PYN8vD4M0Pc4s/7wb1nKjlTJUw+5E9jh26T03fITIZmaafIuwlX+wmdxwIT9Xoy7PlsxOEpzv203A==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
-        "@dfinity/principal": "^2.3.0"
+        "@dfinity/principal": "^2.4.1"
       }
     },
     "node_modules/@dfinity/principal": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.3.0.tgz",
-      "integrity": "sha512-rb3TsxR3L/Vq2GWV/GGIMXPbzDDqxNohPbNW8nJKhpcm8Ds00tCVEmPUDqrn735xJW0Pmzog/6/S1L9jG2UT9g==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.4.1.tgz",
+      "integrity": "sha512-Cz6XQVOwq0TXDBClPbcidDd4SqK1lfr1/Kn34ruDD13xVQ4iaP1iCntzS9O97+vGpY/6jwDtKd32Gn5YJ9BQNw==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -76,9 +76,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.10.0.tgz",
-      "integrity": "sha512-KDCYpIAkgAE4hK5VTe0XAlDeYxh2fWA5pWkUAD3pe9be0UYbrbojC1M7FoueV228OB9ObBytYKG46kFlKjkumA==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.13.1.tgz",
+      "integrity": "sha512-WJ2iYYncfAAWEJQYfUDOYw6e5EFmI8jlmRVOTki+EFVKWo5gmubVT3OguisEqEMCZfxoP1SZKs1DXrYSGYrxfw==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
@@ -743,13 +743,13 @@
       "license": "MIT"
     },
     "node_modules/@noble/curves": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
-      "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.2.tgz",
+      "integrity": "sha512-HxngEd2XUcg9xi20JkwlLCtYwfoFw4JGkuZpT+WlsPD4gB/cxkvTD8fSsoAnphGZhFdZYKeQIPCuFlWPm1uE0g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@noble/hashes": "1.7.1"
+        "@noble/hashes": "1.8.0"
       },
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -759,9 +759,9 @@
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
-      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -1981,9 +1981,9 @@
       "peer": true
     },
     "node_modules/bignumber.js": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
-      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.0.tgz",
+      "integrity": "sha512-EM7aMFTXbptt/wZdMlBv2t8IViwQL+h6SLHosp8Yf0dqJMTnY6iL32opnAB6kAdL0SZPuvcAzFr31o0c/R3/RA==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "best-practices"
   ],
   "peerDependencies": {
-    "@dfinity/utils": ">=2",
+    "@dfinity/utils": "*",
     "@eslint/compat": "^1.2.6",
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.20.0",


### PR DESCRIPTION
# Motivation

The peer dependencies on `@dfinity/utils` in this linter is pain. Everywhere we use it, either it throws error, block or throw warning while fundamentally speaking we do not care if the linter inherits or not that lib. So while it is not fully correct to require `*` since the nullish utils were introduced in v0.0.1x something, we still set `*` as peer to avoid being annoyed.
