### PR TITLE
feat: Disable local rule `use-option-type-wrapper` by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ module.exports = require("@dfinity/eslint-config-oisy-wallet/eslint-local-rules"
 > [!NOTE]
 > This is necessary because the `eslint-plugin-local-rules` plugin we use for custom rules requires a file located at the root and does not offer any customizable location option.
 
-## 🔧 Overriding or Disabling Rules
+## 🔧 Overriding, Enabling, or Disabling Rules
 
 You can override or disable any of the rules provided by this configuration — including custom **local rules** — just like you would with any ESLint config.
 
@@ -99,6 +99,9 @@ module.exports = {
 
     // Disable a local custom rule
     "local/use-nullish-checks": "off",
+
+    // Enable a built-in rule
+    "local-rules/prefer-object-params": "warn",
 
     // Customize severity or options
     "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
@@ -123,6 +126,9 @@ export default [
 
       // Disable a local custom rule
       "local/use-nullish-checks": "off",
+
+      // Enable a built-in rule
+      "local-rules/prefer-object-params": "warn",
 
       // Customize severity or options
       "@typescript-eslint/no-unused-vars": [

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ module.exports = require("@dfinity/eslint-config-oisy-wallet/eslint-local-rules"
 
 ## 🔧 Overriding, Enabling, or Disabling Rules
 
-You can override or disable any of the rules provided by this configuration — including custom **local rules** — just like you would with any ESLint config.
+You can override, enable, or disable any of the rules provided by this configuration — including custom **local rules** — just like you would with any ESLint config.
 
 In your `.eslintrc.js`, simply add a `rules` section:
 

--- a/configs/eslint.rules.mjs
+++ b/configs/eslint.rules.mjs
@@ -51,11 +51,7 @@ export const eslintRules = [
       curly: "error",
       "func-style": "error",
 
-      // TODO: Disabled for now to allow the migration of ESLint v9 in OISY, as the rule is not yet enforced.
-      // It should also be introduced as an optional rule.
-      // "local-rules/use-nullish-checks": "warn",
-
-      "local-rules/use-option-type-wrapper": "warn",
+      "local-rules/prefer-object-params": "warn",
 
       "import/no-duplicates": ["error", { "prefer-inline": true }],
       "import/no-relative-parent-imports": "error",

--- a/configs/eslint.rules.mjs
+++ b/configs/eslint.rules.mjs
@@ -51,8 +51,6 @@ export const eslintRules = [
       curly: "error",
       "func-style": "error",
 
-      "local-rules/prefer-object-params": "warn",
-
       // TODO: Disabled for now to allow the migration of ESLint v9 in OISY, as the rule is not yet enforced.
       // It should also be introduced as an optional rule.
       // "local-rules/use-nullish-checks": "warn",

--- a/rules/use-nullish-checks.cjs
+++ b/rules/use-nullish-checks.cjs
@@ -4,7 +4,7 @@ module.exports = {
     docs: {
       description: "Enforce the use of isNullish functions for nullish checks",
       category: "Best Practices",
-      recommended: true,
+      recommended: false,
     },
     messages: {
       isNullish:

--- a/rules/use-option-type-wrapper.cjs
+++ b/rules/use-option-type-wrapper.cjs
@@ -4,7 +4,7 @@ module.exports = {
     docs: {
       description: "Enforce use of Option<T> instead of T | null | undefined",
       category: "Best Practices",
-      recommended: true,
+      recommended: false,
     },
     messages: {
       useOption:


### PR DESCRIPTION
# Motivation

According to suggestion https://github.com/dfinity/eslint-config-oisy-wallet/issues/135, it make sense to disable local rule `use-option-type-wrapper` by default: it may happen that the consumer does not want to create/use the `Option` type.

The consumer can always turn it on if necessary (updated documentation).

NOTE: local rule `use-nullish-checks` was under the same circumnstances, but its metadata were not updated.
