### PR TITLE
feat: add vitest rule `no-importing-vitest-globals`

### DIFF
--- a/vitest.mjs
+++ b/vitest.mjs
@@ -11,6 +11,7 @@ export default [
 
       "vitest/no-alias-methods": ["error"],
       "vitest/no-duplicate-hooks": ["error"],
+      "vitest/no-importing-vitest-globals": ["error"],
       "vitest/no-test-return-statement": ["error"],
       "vitest/padding-around-all": ["error"],
       "vitest/prefer-comparison-matcher": ["error"],


### PR DESCRIPTION
# Motivation

To be more consistent, we add vitest rule [no-importing-vitest-globals](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-importing-vitest-globals.md) that disallows importing [Vitest globals](https://vitest.dev/config/#globals).