### PR TITLE
feat: add vitest rule `prefer-called-once`

### DIFF
--- a/vitest.mjs
+++ b/vitest.mjs
@@ -14,6 +14,7 @@ export default [
       "vitest/no-test-return-statement": ["error"],
       "vitest/padding-around-all": ["error"],
       "vitest/prefer-comparison-matcher": ["error"],
+      "vitest/prefer-called-once": ["error"],
       "vitest/prefer-each": ["error"],
       "vitest/prefer-equality-matcher": ["error"],
       "vitest/prefer-expect-resolves": ["error"],


### PR DESCRIPTION
# Motivation

We add vitest rule [prefer-called-once](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-called-once.md) that enforces the use of `toBeCalledOnce()` or `toHaveBeenCalledOnce()`.
