### PR TITLE
feat: add vitest rule `no-test-prefixes`

### DIFF
--- a/vitest.mjs
+++ b/vitest.mjs
@@ -11,6 +11,7 @@ export default [
 
       "vitest/no-alias-methods": ["error"],
       "vitest/no-duplicate-hooks": ["error"],
+      "vitest/no-test-prefixes": ["error"],
       "vitest/no-test-return-statement": ["error"],
       "vitest/padding-around-all": ["error"],
       "vitest/prefer-comparison-matcher": ["error"],


### PR DESCRIPTION
# Motivation

To favour the usage of `.skip` and `.only`, we add vitest rule [no-test-prefixes](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-test-prefixes.md).
