### PR TITLE
feat: Add Svelte rule `sort-attributes`

### DIFF
--- a/svelte.mjs
+++ b/svelte.mjs
@@ -61,6 +61,7 @@ export default [
       "svelte/require-event-prefix": ["error"],
       "svelte/shorthand-attribute": ["error"],
       "svelte/shorthand-directive": ["error"],
+      "svelte/sort-attributes": ["error"],
       "svelte/spaced-html-comment": ["error"],
     },
   },


### PR DESCRIPTION
# Motivation

To be more consistent, we enforce Svelte rule [sort-attributes](https://sveltejs.github.io/eslint-plugin-svelte/rules/sort-attributes/) that sorts all the props of a component when rendered/called.

We use it with the default settings. The default order is:

`this` property.
`bind:this` directive.
`id` attribute.
`name` attribute.
`slot` attribute.
`--style-props` (Alphabetical order within the same group.)
`style` attribute, and `style:` directives.
`class` attribute.
`class:` directives. (Alphabetical order within the same group.)
other attributes. (Alphabetical order within the same group.)
`bind:` directives (other then `bind:this`), and `on:` directives.
`use:` directives. (Alphabetical order within the same group.)
`transition:` directive.
`in:` directive.
`out:` directive.
`animate:` directive.
`let:` directives. (Alphabetical order within the same group.)
