### PR TITLE
feat: Use Typescript lint `recommended-type-checked` list

### DIFF
--- a/configs/eslint.core.mjs
+++ b/configs/eslint.core.mjs
@@ -6,7 +6,7 @@ import { eslintIgnore } from "./eslint.ignore.mjs";
 
 export const eslintCoreConfig = [
   js.configs.recommended,
-  ...ts.configs.recommended,
+  ...ts.configs.recommendedTypeChecked,
   prettier,
   ...eslintRules,
   ...eslintIgnore,

--- a/configs/eslint.rules.mjs
+++ b/configs/eslint.rules.mjs
@@ -21,6 +21,7 @@ const gitignorePath = resolveGitIgnorePath();
 
 export const eslintRules = [
   ...(nonNullish(gitignorePath) ? [includeIgnoreFile(gitignorePath)] : []),
+
   {
     plugins: {
       "local-rules": localRules,
@@ -35,7 +36,6 @@ export const eslintRules = [
       "@typescript-eslint/no-inferrable-types": "error",
       "@typescript-eslint/no-non-null-asserted-nullish-coalescing": "error",
       "@typescript-eslint/no-non-null-assertion": "error",
-      "@typescript-eslint/no-unnecessary-type-assertion": "error",
       "@typescript-eslint/no-unused-vars": [
         "warn",
         {
@@ -76,14 +76,26 @@ export const eslintRules = [
       ],
 
       "prefer-template": "error",
-      "require-await": "error",
     },
   },
+
   {
     files: ["**/*.ts"],
 
     rules: {
       "prefer-const": "error",
+    },
+  },
+
+  {
+    files: ["**/*.{js,cjs,mjs}"],
+
+    rules: {
+      "@typescript-eslint/no-unsafe-argument": "off",
+      "@typescript-eslint/no-unsafe-assignment": "off",
+      "@typescript-eslint/no-unsafe-call": "off",
+      "@typescript-eslint/no-unsafe-member-access": "off",
+      "@typescript-eslint/no-unsafe-return": "off",
     },
   },
 ];

--- a/svelte.mjs
+++ b/svelte.mjs
@@ -73,6 +73,7 @@ export default [
       "no-console": "off",
     },
   },
+
   {
     rules: {
       // TODO: Fix after migration to Svelte v5

--- a/tests/explicit-non-void-return-type.spec.ts
+++ b/tests/explicit-non-void-return-type.spec.ts
@@ -1,9 +1,11 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- We are importing a JS module, so we cannot type this properly for now
 const rule = require("../rules/explicit-non-void-return-type.cjs");
 
 const ruleTester = new RuleTester();
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- We are importing a JS module, so we cannot type this properly for now
 ruleTester.run("explicit-non-void-return-type", rule, {
   valid: [
     // Test for implied void returns

--- a/tests/no-relative-imports.spec.ts
+++ b/tests/no-relative-imports.spec.ts
@@ -1,9 +1,11 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- We are importing a JS module, so we cannot type this properly for now
 const rule = require("../rules/no-relative-imports.cjs");
 
 const ruleTester = new RuleTester();
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- We are importing a JS module, so we cannot type this properly for now
 ruleTester.run("no-relative-imports", rule, {
   valid: [
     {

--- a/tests/use-nullish-checks.spec.ts
+++ b/tests/use-nullish-checks.spec.ts
@@ -1,9 +1,11 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- We are importing a JS module, so we cannot type this properly for now
 const rule = require("../rules/use-nullish-checks.cjs");
 
 const ruleTester = new RuleTester();
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- We are importing a JS module, so we cannot type this properly for now
 ruleTester.run("use-nullish-checks", rule, {
   valid: [
     {

--- a/tests/use-option-type-wrapper.spec.ts
+++ b/tests/use-option-type-wrapper.spec.ts
@@ -1,9 +1,11 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- We are importing a JS module, so we cannot type this properly for now
 const rule = require("../rules/use-option-type-wrapper.cjs");
 
 const ruleTester = new RuleTester();
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- We are importing a JS module, so we cannot type this properly for now
 ruleTester.run("use-option-type-wrapper", rule, {
   valid: [
     {


### PR DESCRIPTION
# Motivation

I was thinking of adding quite a lot of more rules for Typescript and I noticed that they were all in the [`recommended-type-checked` definition](https://typescript-eslint.io/users/configs/#recommended-type-checked).

Furthermore we already have some rules enabled from that list, so we can remove them now.

The complete list of rules can be found [here](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/eslintrc/recommended-type-checked.ts).
