### PR TITLE
feat: Add rule no-useless-return

### DIFF
--- a/configs/eslint.rules.mjs
+++ b/configs/eslint.rules.mjs
@@ -64,6 +64,7 @@ export const eslintRules = [
       "no-else-return": ["warn", { allowElseIf: false }],
       "no-unused-vars": "off",
       "no-useless-rename": "error",
+      "no-useless-return": "error",
       "prefer-arrow-callback": "error",
 
       "prefer-arrow/prefer-arrow-functions": [


### PR DESCRIPTION
# Motivation

We would like to avoid unnecessary `return` statements, so we introduce rule [no-useless-return](https://eslint.org/docs/latest/rules/no-useless-return).