### PR TITLE
feat: Optional enable nullish check for nullish booleans

### DIFF
--- a/rules/use-nullish-checks.cjs
+++ b/rules/use-nullish-checks.cjs
@@ -31,10 +31,22 @@ module.exports = {
         "Use nonNullish() instead of direct variable check for nullish checks.",
     },
     fixable: "code",
-    schema: [],
+    schema: [
+      {
+        type: "object",
+        properties: {
+          includeBooleans: {
+            type: "boolean",
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
   },
 
   create: (context) => {
+    const shouldLintBooleans = context.options[0]?.includeBooleans ?? false;
+
     const { sourceCode } = context;
 
     const parserServices = sourceCode?.parserServices ?? context.parserServices;
@@ -165,6 +177,10 @@ module.exports = {
     };
 
     const shouldTreatAsBooleanCondition = (node) => {
+      if (shouldLintBooleans) {
+        return false;
+      }
+
       try {
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         return isBooleanTypeFromTs(node) || isBooleanTypeFromScope(node);

--- a/rules/use-nullish-checks.cjs
+++ b/rules/use-nullish-checks.cjs
@@ -37,6 +37,10 @@ module.exports = {
         properties: {
           includeBooleans: {
             type: "boolean",
+            description:
+              "When true, also enforce nullish checks on variables typed as boolean or nullish boolean. " +
+              "Boolean expressions (comparisons, known boolean methods, literals, negations) are always allowed. " +
+              "Defaults to false.",
           },
         },
         additionalProperties: false,
@@ -176,9 +180,16 @@ module.exports = {
       );
     };
 
+    const isBooleanExpression = (node) =>
+      isBooleanBinaryExpression(node) ||
+      hasKnownBooleanMethodCall(node) ||
+      isNullishUtilityCall(node) ||
+      (node.type === "Literal" && typeof node.value === "boolean") ||
+      (node.type === "UnaryExpression" && node.operator === "!");
+
     const shouldTreatAsBooleanCondition = (node) => {
       if (shouldLintBooleans) {
-        return false;
+        return isBooleanExpression(node);
       }
 
       try {

--- a/tests/use-nullish-checks.spec.ts
+++ b/tests/use-nullish-checks.spec.ts
@@ -66,6 +66,16 @@ ruleTester.run("use-nullish-checks", rule, {
       options: [{ includeBooleans: false }],
       filename,
     },
+    {
+      code: "if (a === b) {}",
+      options: [{ includeBooleans: true }],
+      filename,
+    },
+    {
+      code: "if (!(a === b)) {}",
+      options: [{ includeBooleans: true }],
+      filename,
+    },
   ],
 
   invalid: [
@@ -119,20 +129,6 @@ ruleTester.run("use-nullish-checks", rule, {
       filename,
       errors: [{ messageId: "nonNullish" }],
       output: "if (nonNullish(s)) {}",
-    },
-    {
-      code: "if (a === b) {}",
-      options: [{ includeBooleans: true }],
-      filename,
-      errors: [{ messageId: "nonNullish" }],
-      output: "if (nonNullish(a === b)) {}",
-    },
-    {
-      code: "if (!(a === b)) {}",
-      options: [{ includeBooleans: true }],
-      filename,
-      errors: [{ messageId: "isNullish" }],
-      output: "if (isNullish(a === b)) {}",
     },
     {
       code: "const b: boolean = true; if (b) {}",

--- a/tests/use-nullish-checks.spec.ts
+++ b/tests/use-nullish-checks.spec.ts
@@ -56,6 +56,16 @@ ruleTester.run("use-nullish-checks", rule, {
       code: "const foo: boolean | null | undefined = null; if (foo) {}",
       filename,
     },
+    {
+      code: "if (a === b) {}",
+      options: [{ includeBooleans: false }],
+      filename,
+    },
+    {
+      code: "const b: boolean = true; if (b) {}",
+      options: [{ includeBooleans: false }],
+      filename,
+    },
   ],
 
   invalid: [
@@ -109,6 +119,42 @@ ruleTester.run("use-nullish-checks", rule, {
       filename,
       errors: [{ messageId: "nonNullish" }],
       output: "if (nonNullish(s)) {}",
+    },
+    {
+      code: "if (a === b) {}",
+      options: [{ includeBooleans: true }],
+      filename,
+      errors: [{ messageId: "nonNullish" }],
+      output: "if (nonNullish(a === b)) {}",
+    },
+    {
+      code: "if (!(a === b)) {}",
+      options: [{ includeBooleans: true }],
+      filename,
+      errors: [{ messageId: "isNullish" }],
+      output: "if (isNullish(a === b)) {}",
+    },
+    {
+      code: "const b: boolean = true; if (b) {}",
+      options: [{ includeBooleans: true }],
+      filename,
+      errors: [{ messageId: "nonNullish" }],
+      output: "const b: boolean = true; if (nonNullish(b)) {}",
+    },
+    {
+      code: "const b: boolean | undefined = undefined; if (b) {}",
+      options: [{ includeBooleans: true }],
+      filename,
+      errors: [{ messageId: "nonNullish" }],
+      output: "const b: boolean | undefined = undefined; if (nonNullish(b)) {}",
+    },
+    {
+      code: "const foo: boolean | null | undefined = null; if (!foo) {}",
+      options: [{ includeBooleans: true }],
+      filename,
+      errors: [{ messageId: "isNullish" }],
+      output:
+        "const foo: boolean | null | undefined = null; if (isNullish(foo)) {}",
     },
     {
       code: "const x = foo ? (bar ? 1 : 2) : 3;",


### PR DESCRIPTION
# Motivation

It is useful to provide an optional params to include nullish booleans in rule `use-nullish-checks`.
