### PR TITLE
feat: Add option to ignore `find` in `use-nullish-checks`

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,15 +159,19 @@ This configuration ships with several custom local rules:
 
 The rule accepts an optional configuration object:
 
-| Option            | Type      | Default | Description                                                                                                                                                                                                                                      |
-| ----------------- | --------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `includeBooleans` | `boolean` | `false` | When `true`, also enforce nullish checks on variables typed as `boolean` (or `boolean \| null \| undefined`). Boolean expressions — comparisons, known boolean methods, literals, and negations — are always allowed regardless of this setting. |
+| Option                    | Type      | Default | Description                                                                                                                                                                                                                                      |
+| ------------------------- | --------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `includeBooleans`         | `boolean` | `false` | When `true`, also enforce nullish checks on variables typed as `boolean` (or `boolean \| null \| undefined`). Boolean expressions — comparisons, known boolean methods, literals, and negations — are always allowed regardless of this setting. |
+| `allowFindUndefinedCheck` | `boolean` | `false` | When `true`, allow direct nullish comparisons on the result of `.find()` calls (e.g. `array.find(x => x) === undefined`). Useful because `.find()` legitimately returns `undefined` when no match is found.                                      |
 
 Example:
 
 ```javascript
 // Enable the rule with boolean variable checking
 "local-rules/use-nullish-checks": ["error", { includeBooleans: true }]
+
+// Allow .find() results to be compared with undefined/null directly
+"local-rules/use-nullish-checks": ["error", { allowFindUndefinedCheck: true }]
 ```
 
 With `includeBooleans: true`:
@@ -181,6 +185,18 @@ if (b) {
 
 // ✅ OK — boolean expression, always allowed
 if (a === b) {
+}
+```
+
+With `allowFindUndefinedCheck: true`:
+
+```typescript
+// ✅ OK — .find() result compared with undefined is allowed
+if (array.find((item) => item.id === id) === undefined) {
+}
+
+// ✅ OK — .find() result compared with null is allowed
+if (array.find((item) => item.id === id) !== null) {
 }
 ```
 

--- a/rules/use-nullish-checks.cjs
+++ b/rules/use-nullish-checks.cjs
@@ -42,6 +42,13 @@ module.exports = {
               "Boolean expressions (comparisons, known boolean methods, literals, negations) are always allowed. " +
               "Defaults to false.",
           },
+          allowFindUndefinedCheck: {
+            type: "boolean",
+            description:
+              "When true, allow direct nullish comparisons on the result of .find() calls " +
+              "(e.g. array.find(x => x) === undefined). " +
+              "Defaults to false.",
+          },
         },
         additionalProperties: false,
       },
@@ -49,7 +56,11 @@ module.exports = {
   },
 
   create: (context) => {
-    const shouldLintBooleans = context.options[0]?.includeBooleans ?? false;
+    const [options] = context.options;
+
+    const shouldLintBooleans = options?.includeBooleans ?? false;
+
+    const allowFindUndefinedCheck = options?.allowFindUndefinedCheck ?? false;
 
     const { sourceCode } = context;
 
@@ -204,6 +215,12 @@ module.exports = {
       (expression.type === "Identifier" && expression.name === "undefined") ||
       (expression.type === "Literal" && expression.value === null);
 
+    const isFindCall = (node) =>
+      node.type === "CallExpression" &&
+      node.callee.type === "MemberExpression" &&
+      node.callee.property.type === "Identifier" &&
+      node.callee.property.name === "find";
+
     const getNullishComparisonTarget = (node) => {
       if (node.type !== "BinaryExpression") {
         return;
@@ -286,6 +303,10 @@ module.exports = {
         const target = getNullishComparisonTarget(node);
 
         if (!target) {
+          return;
+        }
+
+        if (allowFindUndefinedCheck && isFindCall(target)) {
           return;
         }
 

--- a/tests/use-nullish-checks.spec.ts
+++ b/tests/use-nullish-checks.spec.ts
@@ -76,6 +76,16 @@ ruleTester.run("use-nullish-checks", rule, {
       options: [{ includeBooleans: true }],
       filename,
     },
+    {
+      code: "array.find(item => item) === null;",
+      options: [{ allowFindUndefinedCheck: true }],
+      filename,
+    },
+    {
+      code: "array.find(item => item) !== undefined;",
+      options: [{ allowFindUndefinedCheck: true }],
+      filename,
+    },
   ],
 
   invalid: [
@@ -175,6 +185,20 @@ ruleTester.run("use-nullish-checks", rule, {
       filename,
       errors: [{ messageId: "nonNullish" }],
       output: "for (; nonNullish(foo); ) {}",
+    },
+    {
+      code: "array.find(item => item) === null;",
+      options: [{ allowFindUndefinedCheck: false }],
+      filename,
+      errors: [{ messageId: "isNullish" }],
+      output: "isNullish(array.find(item => item));",
+    },
+    {
+      code: "array.find(item => item) !== undefined;",
+      options: [{ allowFindUndefinedCheck: false }],
+      filename,
+      errors: [{ messageId: "nonNullish" }],
+      output: "nonNullish(array.find(item => item));",
     },
   ],
 });


### PR DESCRIPTION
# Motivation

As suggested by @peterpeterparker  in https://github.com/dfinity/eslint-config-oisy-wallet/pull/32#pullrequestreview-2426144817 , we add an option to the `use-nullish-check rule`, to ignore the cases for `find` function such as `arr.find(something) === undefined`
