### PR TITLE
chore: release v0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/eslint-config-oisy-wallet",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/eslint-config-oisy-wallet",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^25.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/eslint-config-oisy-wallet",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "Apache-2.0",
   "description": "Shared ESLint configurations from the Oisy Wallet team",
   "repository": {


### PR DESCRIPTION
Cuts a release of the changes currently on `main` that are unreleased since [`v0.3.0`](https://github.com/dfinity/eslint-config-oisy-wallet/releases/tag/v0.3.0).

`0.3.0` → `0.4.0` in `package.json` + `package-lock.json`.

### Included since v0.3.0
- feat: extend `use-nullish-checks` to more statements, `UnaryExpression`, optional nullish-boolean checking, and an option to ignore `find` (#221, #223, #224, #226)
- docs: documentation for custom rules (#225)
- test: type-safe tests + additional `use-nullish-checks` coverage (#220, #222)
- refactor: clarify `BinaryExpression` logic in `use-nullish-checks` (#219)
- various dependency bumps (#215–#217, #228–#232)

### Release process
After merge, cut a GitHub Release tagged `v0.4.0` to trigger the `publish` workflow.

> The ESLint 10 work (#241) is **not** part of this release; it ships separately as `v0.5.0` once merged.