### PR TITLE
chore: release v0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/eslint-config-oisy-wallet",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/eslint-config-oisy-wallet",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^25.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/eslint-config-oisy-wallet",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "description": "Shared ESLint configurations from the Oisy Wallet team",
   "repository": {


### PR DESCRIPTION
Release of the **ESLint 10 support** work. Version-only bump — the functional changes live in #241.

`0.4.0` → `0.5.0` in `package.json` + `package-lock.json`.
